### PR TITLE
fix: Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "type": "git",
         "url": "https://github.com/astahmer/pastable.git"
     },
+    "license": "MIT",
     "author": "Alexandre Stahmer <alexandre.stahmer@gmail.com>",
     "main": "dist/pastable.cjs.js",
     "module": "dist/pastable.esm.js",


### PR DESCRIPTION
See https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license